### PR TITLE
ci: :construction_worker: Add CI job to check rust tests results if they run

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -128,3 +128,4 @@ jobs:
             fi
           else
             echo "No relevant changes — skipping rust tests"
+          fi


### PR DESCRIPTION
This PR adds a new job at the end of the `DataHave Operator Rust Tests` (`rust-tests.yml`) that checks:
- If the tests were skipped (no changes in the `operator/` directory), it succeeds.
- If the tests run and succeeded, it succeeds.
- If the tests run and failed, it fails.

This is useful to set this job as required in our merging ruleset, and account for cases where the tests are skipped.