### PR TITLE
Temporarily rename main runtime as `datahaven-stagenet`

### DIFF
--- a/operator/runtime/src/lib.rs
+++ b/operator/runtime/src/lib.rs
@@ -66,8 +66,8 @@ impl_opaque_keys! {
 // https://docs.substrate.io/main-docs/build/upgrade#runtime-versioning
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: Cow::Borrowed("datahaven-runtime"),
-    impl_name: Cow::Borrowed("datahaven-runtime"),
+    spec_name: Cow::Borrowed("datahaven-stagenet"),
+    impl_name: Cow::Borrowed("datahaven-stagenet"),
     authoring_version: 1,
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,


### PR DESCRIPTION
Currently, it is not possible to sign a transaction when submitting an extrinsic with Polkadot.js Apps. This is due to the fact that Polkadot.js does not consider DataHaven chain as an Ethereum chain (exclusively using AccountId20 accounts).

This PR renames the runtime to `datahaven-stagenet` and this should make Polkadot.js only use Ethereum AccountId20 style accounts once this [PR](https://github.com/polkadot-js/apps/pull/11501) is merged.

Note: another 'trick' to get it working locally, meanwhile, is to name the runtime any of the Moonbeam runtimes (e.g. `moonbase`).