### PR TITLE
fix: 🔧  execution relayer config mismatch

### DIFF
--- a/test/configs/snowbridge/execution-relay.json
+++ b/test/configs/snowbridge/execution-relay.json
@@ -33,7 +33,7 @@
     },
     "instantVerification": false,
     "schedule": {
-        "id": 0,
+        "id": null,
         "totalRelayerCount": 1,
         "sleepInterval": 1
     }


### PR DESCRIPTION
There was an ID mismatch with what was expected by the relayer and our config file.