### PR TITLE
fix: 🔨 Fix testnet Identity pallet's configuration

### DIFF
--- a/operator/runtime/testnet/src/configs/mod.rs
+++ b/operator/runtime/testnet/src/configs/mod.rs
@@ -493,7 +493,6 @@ impl pallet_identity::Config for Runtime {
     type MaxSubAccounts = MaxSubAccounts;
     type IdentityInformation = pallet_identity::legacy::IdentityInfo<MaxAdditionalFields>;
     type MaxRegistrars = MaxRegistrars;
-    type Slashed = ();
     type Slashed = Treasury;
     type ForceOrigin = IdentityForceOrigin;
     type RegistrarOrigin = IdentityRegistrarOrigin;


### PR DESCRIPTION
This pull request updates the identity pallet configuration to ensure that slashed funds are now sent to the treasury, rather than being discarded. This change is a step towards proper fund management within the runtime.

Identity pallet configuration update:

* Changed the `Slashed` associated type implementation in the `pallet_identity::Config` for `Runtime` to use `Treasury`, so that slashed funds are now sent to the treasury instead of being ignored.