### PR TITLE
fix: 🔧  align BabeDataGetter implementation for all runtimes

### DIFF
--- a/operator/runtime/mainnet/src/configs/storagehub/mod.rs
+++ b/operator/runtime/mainnet/src/configs/storagehub/mod.rs
@@ -12,7 +12,7 @@ use frame_support::pallet_prelude::DispatchClass;
 use frame_support::traits::AsEnsureOriginWithArg;
 use frame_support::{
     parameter_types,
-    traits::{ConstU128, ConstU32, ConstU64},
+    traits::{ConstU128, ConstU32, ConstU64, Randomness},
     weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -109,15 +109,21 @@ impl pallet_randomness::Config for Runtime {
 pub struct BabeDataGetter;
 impl pallet_randomness::GetBabeData<u64, Hash> for BabeDataGetter {
     fn get_epoch_index() -> u64 {
-        pallet_babe::Pallet::<Runtime>::current_epoch().epoch_index
+        pallet_babe::Pallet::<Runtime>::epoch_index()
     }
     fn get_epoch_randomness() -> Hash {
-        sp_core::H256::from(pallet_babe::Pallet::<Runtime>::current_epoch().randomness)
+        // We use `RandomnessFromOneEpochAgo` implementation of the `Randomness` trait here, which hashes the `NextRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the last block of the last epoch (`_n`). The hashed
+        // received is the hash of `NextRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h, _n) = pallet_babe::RandomnessFromOneEpochAgo::<Runtime>::random(b"");
+        h
     }
     fn get_parent_randomness() -> Hash {
-        sp_core::H256::from(
-            pallet_babe::Pallet::<Runtime>::author_vrf_randomness().unwrap_or_default(),
-        )
+        // We use `ParentBlockRandomness` implementation of the `Randomness` trait here, which hashes the `AuthorVrfRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the parent block (`_n`). The hashed received is the
+        // hash of `AuthorVrfRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h_opt, _n) = pallet_babe::ParentBlockRandomness::<Runtime>::random(b"");
+        h_opt.unwrap_or_default()
     }
 }
 

--- a/operator/runtime/stagenet/src/configs/storagehub/mod.rs
+++ b/operator/runtime/stagenet/src/configs/storagehub/mod.rs
@@ -12,7 +12,7 @@ use frame_support::pallet_prelude::DispatchClass;
 use frame_support::traits::AsEnsureOriginWithArg;
 use frame_support::{
     parameter_types,
-    traits::{ConstU128, ConstU32, ConstU64},
+    traits::{ConstU128, ConstU32, ConstU64, Randomness},
     weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -109,13 +109,21 @@ impl pallet_randomness::Config for Runtime {
 pub struct BabeDataGetter;
 impl pallet_randomness::GetBabeData<u64, Hash> for BabeDataGetter {
     fn get_epoch_index() -> u64 {
-        pallet_babe::Pallet::<Runtime>::current_epoch().epoch_index
+        pallet_babe::Pallet::<Runtime>::epoch_index()
     }
     fn get_epoch_randomness() -> Hash {
-        sp_core::H256::from(pallet_babe::Pallet::<Runtime>::current_epoch().randomness)
+        // We use `RandomnessFromOneEpochAgo` implementation of the `Randomness` trait here, which hashes the `NextRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the last block of the last epoch (`_n`). The hashed
+        // received is the hash of `NextRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h, _n) = pallet_babe::RandomnessFromOneEpochAgo::<Runtime>::random(b"");
+        h
     }
     fn get_parent_randomness() -> Hash {
-        sp_core::H256::from(pallet_babe::Pallet::<Runtime>::current_epoch().randomness)
+        // We use `ParentBlockRandomness` implementation of the `Randomness` trait here, which hashes the `AuthorVrfRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the parent block (`_n`). The hashed received is the
+        // hash of `AuthorVrfRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h_opt, _n) = pallet_babe::ParentBlockRandomness::<Runtime>::random(b"");
+        h_opt.unwrap_or_default()
     }
 }
 

--- a/operator/runtime/testnet/src/configs/storagehub/mod.rs
+++ b/operator/runtime/testnet/src/configs/storagehub/mod.rs
@@ -12,7 +12,7 @@ use frame_support::pallet_prelude::DispatchClass;
 use frame_support::traits::AsEnsureOriginWithArg;
 use frame_support::{
     parameter_types,
-    traits::{ConstU128, ConstU32, ConstU64},
+    traits::{ConstU128, ConstU32, ConstU64, Randomness},
     weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -109,13 +109,21 @@ impl pallet_randomness::Config for Runtime {
 pub struct BabeDataGetter;
 impl pallet_randomness::GetBabeData<u64, Hash> for BabeDataGetter {
     fn get_epoch_index() -> u64 {
-        pallet_babe::Pallet::<Runtime>::current_epoch().epoch_index
+        pallet_babe::Pallet::<Runtime>::epoch_index()
     }
     fn get_epoch_randomness() -> Hash {
-        sp_core::H256::from(pallet_babe::Pallet::<Runtime>::current_epoch().randomness)
+        // We use `RandomnessFromOneEpochAgo` implementation of the `Randomness` trait here, which hashes the `NextRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the last block of the last epoch (`_n`). The hashed
+        // received is the hash of `NextRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h, _n) = pallet_babe::RandomnessFromOneEpochAgo::<Runtime>::random(b"");
+        h
     }
     fn get_parent_randomness() -> Hash {
-        sp_core::H256::from(pallet_babe::Pallet::<Runtime>::current_epoch().randomness)
+        // We use `ParentBlockRandomness` implementation of the `Randomness` trait here, which hashes the `AuthorVrfRandomness`
+        // stored by the BABE pallet, and is valid for commitments until the parent block (`_n`). The hashed received is the
+        // hash of `AuthorVrfRandomness` concatenated with the `subject` parameter provided (in this case empty).
+        let (h_opt, _n) = pallet_babe::ParentBlockRandomness::<Runtime>::random(b"");
+        h_opt.unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Based on [this comment](https://github.com/datahaven-xyz/datahaven/pull/148#pullrequestreview-3195433668), I took the SH [implementation](https://github.com/Moonsong-Labs/storage-hub/blob/3e5f774c64a944fc4d4754c239a7af3aad5f5ec5/runtime/solochain-evm/src/configs/mod.rs#L1124) of the `BabeDataGetter` and aligned all three runtimes with this implementation.