### PR TITLE
fix: Fix Production Docker image build

### DIFF
--- a/.github/workflows/DOCKER-PROD.yml
+++ b/.github/workflows/DOCKER-PROD.yml
@@ -22,8 +22,7 @@ on:
 
 jobs:
   build-test-push:
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.last_tag_extractor.outputs.last_tag_value }}
     defaults:


### PR DESCRIPTION
 Self-hosted runners w/ Podman don't support Docker buildx.