### PR TITLE
ci: remove nextest archive

### DIFF
--- a/.github/workflows/task-rust-tests.yml
+++ b/.github/workflows/task-rust-tests.yml
@@ -1,9 +1,7 @@
 # Rust Tests: CI for Rust components (DataHaven runtime and node Rust tests)
 #
 # Overview:
-# 1. Prepare: This job handles the setup phase where the cargo nextest archive is created
-#    and uploaded to the workflow for use in the subsequent jobs
-# 2. All Rust Tests: Executes the full suite of Rust tests across two partitions to
+# All Rust Tests: Executes the full suite of Rust tests across two partitions to
 #    to reduce total execution time.
 
 name: DataHaven Operator Rust Tests
@@ -59,10 +57,6 @@ jobs:
     runs-on:
       group: DH-runners
     steps:
-      - name: Cleanup test artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: nextest-archive
       - name: Validate test results
         run: |
           echo "matrix result: ${{ needs.all-rust-tests.result }}"


### PR DESCRIPTION
Removing the nextest archive steps from the CI because it is taking a lot of time to download.

From latest ci runs downloading take 17min.
