### PR TITLE
fix: allow to start the indexer even without any provider set

### DIFF
--- a/operator/node/src/service.rs
+++ b/operator/node/src/service.rs
@@ -875,7 +875,11 @@ where
         };
     } else {
         return new_full_impl::<UserRole, NoStorageLayer, Runtime, RuntimeApi, N>(
-            config, eth_config, None, None, None,
+            config,
+            eth_config,
+            None,
+            indexer_options,
+            fisherman_options,
         )
         .await;
     };


### PR DESCRIPTION
We allow to pass only indexer configuration even is we are not running as a MSP or a BSP.