### PR TITLE
fix: the Dockerfile error when running e2e tests

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -15,7 +15,11 @@
 #   - GHCR: ghcr.io/datahaven-xyz/datahaven/datahaven (CI)
 #   - DockerHub: datahavenxyz/datahaven (releases)
 
-FROM debian:stable AS builder
+FROM debian:stable-slim
+
+LABEL version="0.3.0"
+LABEL description="DataHaven Node - Release Build"
+LABEL maintainer="steve@moonsonglabs.com"
 
 # Install CA certificates and libpq5 for the release build
 RUN apt-get update && \
@@ -26,31 +30,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-FROM debian:stable-slim
-
-LABEL version="0.3.0"
-LABEL description="DataHaven Node - Release Build"
-LABEL maintainer="steve@moonsonglabs.com"
-
-# Copy CA certificates and shared libraries from builder
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder \
-    /lib/x86_64-linux-gnu/libpq.so.5 \
-    /lib/x86_64-linux-gnu/libssl.so.3 \
-    /lib/x86_64-linux-gnu/libcrypto.so.3 \
-    /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 \
-    /lib/x86_64-linux-gnu/libldap.so.2 \
-    /lib/x86_64-linux-gnu/libz.so.1 \
-    /lib/x86_64-linux-gnu/libzstd.so.1 \
-    /lib/x86_64-linux-gnu/libkrb5.so.3 \
-    /lib/x86_64-linux-gnu/libk5crypto.so.3 \
-    /lib/x86_64-linux-gnu/libcom_err.so.2 \
-    /lib/x86_64-linux-gnu/libkrb5support.so.0 \
-    /lib/x86_64-linux-gnu/liblber.so.2 \
-    /lib/x86_64-linux-gnu/libsasl2.so.2 \
-    /lib/x86_64-linux-gnu/libkeyutils.so.1 \
-    /lib/x86_64-linux-gnu/
-
 # Create datahaven user and directories
 RUN useradd -m -u 1000 -U -s /bin/sh -d /datahaven datahaven && \
     mkdir -p /datahaven/.local/share /data && \
@@ -60,9 +39,12 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /datahaven datahaven && \
 USER datahaven
 
 # Copy pre-built binary
-COPY --chown=datahaven:datahaven build/* /usr/local/bin
+COPY --chown=datahaven:datahaven ./operator/target/release/datahaven-node /usr/local/bin
 # Make binary executable
 RUN chmod uog+x /usr/local/bin/datahaven*
+
+
+RUN /usr/local/bin/datahaven-node --version
 
 # Expose ports
 # 30333: p2p networking

--- a/test/package.json
+++ b/test/package.json
@@ -7,7 +7,7 @@
     "cli": "bun run cli/index.ts",
     "fmt": "biome check .",
     "fmt:fix": "biome check --write .",
-    "build:docker:operator": "docker build --no-cache --platform linux/amd64 -t datahavenxyz/datahaven:local -f ../docker/datahaven-dev.Dockerfile ../.",
+    "build:docker:operator": "docker build --no-cache --platform linux/amd64 -t datahavenxyz/datahaven:local -f ../operator/Dockerfile ../.",
     "generate:wagmi": "wagmi generate",
     "generate:snowbridge-cfgs": "bun -e \"import {generateSnowbridgeConfigs} from './scripts/gen-snowbridge-cfgs.ts'; await generateSnowbridgeConfigs()\"",
     "generate:types": "(cd ../operator && cargo build --release) && bun x papi add --wasm \"../operator/target/release/wbuild/datahaven-stagenet-runtime/datahaven_stagenet_runtime.wasm\" datahaven",


### PR DESCRIPTION
This PR fix the error with user when running the dockerfile for e2e tests. It also simplify the build file and do not copy the lib needed and instead install them in a more standard way.