### PR TITLE
fix: 🪳 Fix gas cost in collective precompile

### DIFF
--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -9283,6 +9283,7 @@ name = "pallet-evm-precompile-collective"
 version = "0.1.0"
 dependencies = [
  "evm",
+ "fp-account",
  "fp-evm",
  "frame-support",
  "frame-system",

--- a/operator/precompiles/collective/Cargo.toml
+++ b/operator/precompiles/collective/Cargo.toml
@@ -18,6 +18,7 @@ sp-std = { workspace = true }
 
 # Frontier
 evm = { workspace = true, features = ["with-codec"] }
+fp-account = { workspace = true }
 fp-evm = { workspace = true }
 pallet-evm = { workspace = true, features = ["forbid-evm-reentrancy"] }
 precompile-utils = { workspace = true }

--- a/operator/precompiles/collective/src/lib.rs
+++ b/operator/precompiles/collective/src/lib.rs
@@ -19,6 +19,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::marker::PhantomData;
+use fp_account::AccountId20;
 use fp_evm::Log;
 use frame_support::{
     dispatch::{GetDispatchInfo, Pays, PostDispatchInfo},
@@ -27,7 +28,7 @@ use frame_support::{
     weights::Weight,
 };
 use pallet_evm::AddressMapping;
-use parity_scale_codec::DecodeLimit as _;
+use parity_scale_codec::{DecodeLimit as _, MaxEncodedLen};
 use precompile_utils::prelude::*;
 use sp_core::{Decode, Get, H160, H256};
 use sp_runtime::traits::Dispatchable;
@@ -317,9 +318,11 @@ where
     #[precompile::public("members()")]
     #[precompile::view]
     fn members(handle: &mut impl PrecompileHandle) -> EvmResult<Vec<Address>> {
-        // Members: Vec(20 * MaxMembers)
+        // Record cost of reading the Members storage item, which contains up to MaxMembers accounts
+        // Cost: AccountId20 size × MaxMembers
         handle.record_db_read::<Runtime>(
-            20 * (<Runtime as pallet_collective::Config<Instance>>::MaxProposals::get() as usize),
+            AccountId20::max_encoded_len()
+                * (<Runtime as pallet_collective::Config<Instance>>::MaxMembers::get() as usize),
         )?;
 
         let members = pallet_collective::Members::<Runtime, Instance>::get();
@@ -331,9 +334,11 @@ where
     #[precompile::public("isMember(address)")]
     #[precompile::view]
     fn is_member(handle: &mut impl PrecompileHandle, account: Address) -> EvmResult<bool> {
-        // Members: Vec(20 * MaxMembers)
+        // Record cost of reading the Members storage item, which contains up to MaxMembers accounts
+        // Cost: AccountId20 size × MaxMembers
         handle.record_db_read::<Runtime>(
-            20 * (<Runtime as pallet_collective::Config<Instance>>::MaxProposals::get() as usize),
+            AccountId20::max_encoded_len()
+                * (<Runtime as pallet_collective::Config<Instance>>::MaxMembers::get() as usize),
         )?;
 
         let account = Runtime::AddressMapping::into_account_id(account.into());


### PR DESCRIPTION
Cherry-pick fix from https://github.com/moonbeam-foundation/moonbeam/pull/3540 for the Collective precompile.

> In the `members` and `is_member` functions, the `MaxProposals` value was being used instead of `MaxMembers` to record gas costs for database access.
