### PR TITLE
fix: use binary search for eth gas estimate

### DIFF
--- a/operator/node/Cargo.toml
+++ b/operator/node/Cargo.toml
@@ -92,7 +92,7 @@ fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }
 fc-mapping-sync = { workspace = true, features = ["sql"] }
-fc-rpc = { workspace = true, features = ["txpool"] }
+fc-rpc = { workspace = true, features = ["txpool", "rpc-binary-search-estimate"] }
 fc-rpc-core = { workspace = true, features = ["txpool"] }
 fc-storage = { workspace = true }
 fp-account = { workspace = true }


### PR DESCRIPTION
## Summary

  - Build the node with Frontier’s rpc-binary-search-estimate feature so eth_estimateGas runs the same iterative search as Moonbeam.
  - Instead of returning the gas spent by a single max-allowance dry run, the RPC now repeatedly replays the transaction while shrinking the gas cap until it finds the smallest limit that still succeeds.

  
