### PR TITLE
fix: 🔨 Enable BEEFY equivocation reporting in all runtimes

### DIFF
--- a/operator/runtime/mainnet/src/configs/mod.rs
+++ b/operator/runtime/mainnet/src/configs/mod.rs
@@ -511,7 +511,8 @@ impl pallet_beefy::Config for Runtime {
     type AncestryHelper = BeefyMmrLeaf;
     type WeightInfo = ();
     type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, BeefyId)>>::Proof;
-    type EquivocationReportSystem = ();
+    type EquivocationReportSystem =
+        pallet_beefy::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;
 }
 
 parameter_types! {

--- a/operator/runtime/stagenet/src/configs/mod.rs
+++ b/operator/runtime/stagenet/src/configs/mod.rs
@@ -508,7 +508,8 @@ impl pallet_beefy::Config for Runtime {
     type AncestryHelper = BeefyMmrLeaf;
     type WeightInfo = ();
     type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, BeefyId)>>::Proof;
-    type EquivocationReportSystem = ();
+    type EquivocationReportSystem =
+        pallet_beefy::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;
 }
 
 parameter_types! {

--- a/operator/runtime/testnet/src/configs/mod.rs
+++ b/operator/runtime/testnet/src/configs/mod.rs
@@ -511,7 +511,8 @@ impl pallet_beefy::Config for Runtime {
     type AncestryHelper = BeefyMmrLeaf;
     type WeightInfo = ();
     type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, BeefyId)>>::Proof;
-    type EquivocationReportSystem = ();
+    type EquivocationReportSystem =
+        pallet_beefy::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;
 }
 
 parameter_types! {


### PR DESCRIPTION
## Summary

- Enables BEEFY equivocation reporting which was previously disabled (set to `()`)
- Configures `pallet_beefy::EquivocationReportSystem` in all three runtimes (mainnet, stagenet, testnet)
- Without this fix, validators could sign conflicting BEEFY commitments without any slashing consequences

## Problem

The `EquivocationReportSystem` type in `pallet_beefy::Config` was set to `()`, which completely disabled BEEFY equivocation reporting. This is a security issue because:

1. BEEFY validators could sign two different commitments at the same block height (equivocation)
2. There was no mechanism to report and slash such misbehavior
3. This undermines the security guarantees of the BEEFY consensus protocol

## Solution

Configure the proper equivocation report system using the same pattern as BABE and GRANDPA:

```rust
type EquivocationReportSystem =
    pallet_beefy::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;
```

This uses:
- `Offences` pallet to record equivocations
- `Historical` pallet for validator proof verification  
- `ReportLongevity` parameter (based on bonding duration) for the reporting window