### PR TITLE
feat: ✨ Bump client version to v0.8.1

### DIFF
--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -1442,7 +1442,7 @@ dependencies = [
  "pallet-message-queue",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "datahaven-mainnet-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bridge-hub-common 0.13.1",
  "datahaven-runtime-common",
@@ -2637,8 +2637,8 @@ dependencies = [
  "shp-treasury-funding",
  "shp-tx-implicits-runtime-api",
  "smallvec",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "datahaven-node"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-channel 1.9.0",
  "clap",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "datahaven-runtime-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "fp-account",
  "frame-support",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "datahaven-stagenet-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bridge-hub-common 0.13.1",
  "datahaven-runtime-common",
@@ -2928,8 +2928,8 @@ dependencies = [
  "shp-treasury-funding",
  "shp-tx-implicits-runtime-api",
  "smallvec",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "datahaven-testnet-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bridge-hub-common 0.13.1",
  "datahaven-runtime-common",
@@ -3080,8 +3080,8 @@ dependencies = [
  "shp-treasury-funding",
  "shp-tx-implicits-runtime-api",
  "smallvec",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "dhp-bridge"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3280,7 +3280,7 @@ dependencies = [
  "pallet-datahaven-native-transfer",
  "pallet-external-validators",
  "parity-scale-codec",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "sp-core",
  "sp-std",
@@ -8509,7 +8509,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-datahaven-native-transfer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8517,7 +8517,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-outbound-queue-primitives",
  "sp-core",
  "sp-io",
@@ -8621,7 +8621,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-balances-erc20"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-batch"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-call-permit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-datahaven-native-transfer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8763,7 +8763,7 @@ dependencies = [
  "parity-scale-codec",
  "precompile-utils",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-outbound-queue-primitives",
  "sp-core",
  "sp-io",
@@ -8842,7 +8842,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-proxy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-registry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8937,7 +8937,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-outbound-queue-primitives",
  "sp-core",
  "sp-io",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-external-validators"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8971,7 +8971,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-external-validators-rewards"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -8986,7 +8986,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
  "sp-core",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-external-validators-rewards-runtime-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-merkle-tree",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-outbound-commitment-store"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14518,7 +14518,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -14562,7 +14562,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bp-relayers",
  "ethabi-decode",
@@ -14662,8 +14662,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-verification-primitives",
  "sp-core",
  "sp-io",
@@ -14676,7 +14676,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-merkle-tree"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "array-bytes",
  "hex",
@@ -14717,7 +14717,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -14729,7 +14729,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-verification-primitives",
  "sp-arithmetic",
  "sp-core",
@@ -14743,12 +14743,12 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-v2-runtime-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
  "sp-api",
@@ -14758,7 +14758,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14771,8 +14771,8 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-ethereum 0.3.0",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-pallet-ethereum-client-fixtures",
@@ -14788,8 +14788,8 @@ name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.9.0"
 dependencies = [
  "hex-literal 0.3.4",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "sp-core",
  "sp-std",
@@ -14797,7 +14797,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue-v2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "alloy-core",
  "bp-relayers",
@@ -14811,8 +14811,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-pallet-ethereum-client",
  "snowbridge-pallet-inbound-queue-v2-fixtures",
@@ -14833,8 +14833,8 @@ name = "snowbridge-pallet-inbound-queue-v2-fixtures"
 version = "0.10.0"
 dependencies = [
  "hex-literal 0.3.4",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "sp-core",
  "sp-std",
@@ -14864,7 +14864,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue-v2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "alloy-core",
  "bp-relayers",
@@ -14878,8 +14878,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "snowbridge-beacon-primitives 0.8.0",
- "snowbridge-core 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
+ "snowbridge-core 0.8.1",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
@@ -14910,7 +14910,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-outbound-queue-primitives",
  "snowbridge-pallet-outbound-queue",
  "sp-core",
@@ -14923,7 +14923,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-system-v2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14935,7 +14935,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "snowbridge-outbound-queue-primitives",
  "snowbridge-pallet-outbound-queue-v2",
  "snowbridge-pallet-system",
@@ -14951,10 +14951,10 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-v2-runtime-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "parity-scale-codec",
- "snowbridge-core 0.8.0",
+ "snowbridge-core 0.8.1",
  "sp-api",
  "sp-std",
  "staging-xcm",
@@ -14962,7 +14962,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-test-utils"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14982,12 +14982,12 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-verification-primitives"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-beacon-primitives 0.8.0",
+ "snowbridge-beacon-primitives 0.8.1",
  "sp-core",
  "sp-std",
 ]

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 homepage = "https://datahaven.xyz/"
 license = "GPL-3"
 repository = "https://github.com/datahavenxyz/datahaven"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace]
 members = [


### PR DESCRIPTION
This PR bumps the client version to v0.8.1 for an upcoming client hotfix release (base branch is `perm-client-v0.8.0`).