### PR TITLE
build: :arrow_up: Upgrade to SH v0.2.2

### DIFF
--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "pallet-bucket-nfts"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "pallet-cr-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-file-system"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "fp-account",
  "fp-evm",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "pallet-file-system"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "pallet-file-system-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "pallet-payment-streams"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "pallet-payment-streams-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "pallet-proofs-dealer"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "pallet-proofs-dealer-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9342,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9483,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "pallet-storage-providers"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9505,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "pallet-storage-providers-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13646,7 +13646,7 @@ dependencies = [
 [[package]]
 name = "shc-actors-derive"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -13659,7 +13659,7 @@ dependencies = [
 [[package]]
 name = "shc-actors-framework"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -13677,7 +13677,7 @@ dependencies = [
 [[package]]
 name = "shc-blockchain-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13731,7 +13731,7 @@ dependencies = [
 [[package]]
 name = "shc-blockchain-service-db"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "chrono",
  "diesel",
@@ -13755,7 +13755,7 @@ dependencies = [
 [[package]]
 name = "shc-client"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13821,7 +13821,7 @@ dependencies = [
 [[package]]
 name = "shc-common"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -13885,7 +13885,7 @@ dependencies = [
 [[package]]
 name = "shc-file-manager"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "bincode",
  "hash-db",
@@ -13909,7 +13909,7 @@ dependencies = [
 [[package]]
 name = "shc-file-transfer-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13938,7 +13938,7 @@ dependencies = [
 [[package]]
 name = "shc-fisherman-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "async-trait",
  "diesel",
@@ -13968,7 +13968,7 @@ dependencies = [
 [[package]]
 name = "shc-forest-manager"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -13993,7 +13993,7 @@ dependencies = [
 [[package]]
 name = "shc-indexer-db"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -14021,7 +14021,7 @@ dependencies = [
 [[package]]
 name = "shc-indexer-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -14072,7 +14072,7 @@ dependencies = [
 [[package]]
 name = "shc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14124,7 +14124,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "shp-constants"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14133,7 +14133,7 @@ dependencies = [
 [[package]]
 name = "shp-data-price-updater"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14148,7 +14148,7 @@ dependencies = [
 [[package]]
 name = "shp-file-key-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14166,7 +14166,7 @@ dependencies = [
 [[package]]
 name = "shp-file-metadata"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "hex",
  "num-bigint",
@@ -14182,7 +14182,7 @@ dependencies = [
 [[package]]
 name = "shp-forest-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14199,7 +14199,7 @@ dependencies = [
 [[package]]
 name = "shp-opaque"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "sp-runtime",
 ]
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "shp-session-keys"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14222,7 +14222,7 @@ dependencies = [
 [[package]]
 name = "shp-traits"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14236,7 +14236,7 @@ dependencies = [
 [[package]]
 name = "shp-treasury-funding"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "log",
  "shp-traits",
@@ -14247,7 +14247,7 @@ dependencies = [
 [[package]]
 name = "shp-tx-implicits-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14260,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "shp-types"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.1#25e8dbbc679b46fc7c955ee5a2707dfcaab1ca2b"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.2#5e53d4c3e6b6d9524968c9149f9542a99ca0e72d"
 dependencies = [
  "sp-core",
  "sp-runtime",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -266,44 +266,44 @@ fc-storage = { git = "https://github.com/polkadot-evm/frontier", branch = "stabl
 
 # StorageHub
 ## Runtime
-pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-storage-hub-runtime = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
+pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+storage-hub-runtime = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
 ## Client
 cumulus-client-service = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2412-6", default-features = false }
-shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
-shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
+shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
+shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
 ## Precompiles
-pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.1", default-features = false }
+pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.2", default-features = false }
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of


### PR DESCRIPTION
Upgrades to StorageHub version 0.2.2, which includes a fix in the Indexer handling of files in the database. No breaking changes.