### PR TITLE
fix: Grant required permissions to reusable workflows in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,10 +11,12 @@ on:
   pull_request:
     branches: [main]
 
-# Explicit minimal permissions
-# Note: Reusable workflows define their own permissions
+# Permissions granted to reusable workflows
+# Note: Called workflows (workflow_call) are constrained by these permissions
 permissions:
   contents: read
+  actions: write    # Required for artifact upload/download in build-operator, moonwall-tests
+  packages: write   # Required for docker-build-ci to push to ghcr.io
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

Fixes the CI failure introduced by #349 where reusable workflows couldn't use the permissions they declared.

## Root Cause

When using `workflow_call` (reusable workflows), the **called workflow's permissions are constrained by the caller**. A called workflow cannot request more permissions than the calling workflow grants.

PR #349 added explicit permissions to individual workflows (e.g., `actions: write` in task-build-operator.yml), but removed them from CI.yml. This caused failures because:

```
CI.yml (contents: read only)
    └── task-build-operator.yml (requests actions: write)
        └── FAILS: caller doesn't grant actions: write
```

## Fix

Grant the necessary permissions in CI.yml so called workflows can use them:

```yaml
permissions:
  contents: read
  actions: write    # For artifact upload/download
  packages: write   # For ghcr.io push
```

## Why the individual workflow permissions still matter

The explicit permissions in called workflows are still valuable for:
1. **Documentation** - Makes the intent clear
2. **Direct invocation** - Works when called via `workflow_dispatch`
3. **Defense in depth** - If CI.yml grants more than needed, called workflows still request only what they need