### PR TITLE
build: :arrow_up: Upgrade to StorageHub version 0.2.8

### DIFF
--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "pallet-bucket-nfts"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "pallet-cr-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-file-system"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "fp-account",
  "fp-evm",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "pallet-file-system"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "pallet-file-system-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9251,7 +9251,7 @@ dependencies = [
 [[package]]
 name = "pallet-payment-streams"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "pallet-payment-streams-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "pallet-proofs-dealer"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "pallet-proofs-dealer-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9343,7 +9343,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "pallet-storage-providers"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9506,7 +9506,7 @@ dependencies = [
 [[package]]
 name = "pallet-storage-providers-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13647,7 +13647,7 @@ dependencies = [
 [[package]]
 name = "shc-actors-derive"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -13660,7 +13660,7 @@ dependencies = [
 [[package]]
 name = "shc-actors-framework"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "bincode",
@@ -13678,7 +13678,7 @@ dependencies = [
 [[package]]
 name = "shc-blockchain-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13732,7 +13732,7 @@ dependencies = [
 [[package]]
 name = "shc-blockchain-service-db"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "chrono",
  "diesel",
@@ -13756,7 +13756,7 @@ dependencies = [
 [[package]]
 name = "shc-client"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13822,7 +13822,7 @@ dependencies = [
 [[package]]
 name = "shc-common"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -13886,7 +13886,7 @@ dependencies = [
 [[package]]
 name = "shc-file-manager"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "bincode",
  "hash-db",
@@ -13910,7 +13910,7 @@ dependencies = [
 [[package]]
 name = "shc-file-transfer-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "shc-fisherman-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "async-trait",
  "diesel",
@@ -13969,7 +13969,7 @@ dependencies = [
 [[package]]
 name = "shc-forest-manager"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "async-trait",
  "bincode",
@@ -13994,7 +13994,7 @@ dependencies = [
 [[package]]
 name = "shc-indexer-db"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -14022,7 +14022,7 @@ dependencies = [
 [[package]]
 name = "shc-indexer-service"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "shc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14125,7 +14125,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "shp-constants"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14134,7 +14134,7 @@ dependencies = [
 [[package]]
 name = "shp-data-price-updater"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14149,7 +14149,7 @@ dependencies = [
 [[package]]
 name = "shp-file-key-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14167,7 +14167,7 @@ dependencies = [
 [[package]]
 name = "shp-file-metadata"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "hex",
  "num-bigint",
@@ -14183,7 +14183,7 @@ dependencies = [
 [[package]]
 name = "shp-forest-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14200,7 +14200,7 @@ dependencies = [
 [[package]]
 name = "shp-opaque"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "sp-runtime",
 ]
@@ -14208,7 +14208,7 @@ dependencies = [
 [[package]]
 name = "shp-session-keys"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14223,7 +14223,7 @@ dependencies = [
 [[package]]
 name = "shp-traits"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14237,7 +14237,7 @@ dependencies = [
 [[package]]
 name = "shp-treasury-funding"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "log",
  "shp-traits",
@@ -14248,7 +14248,7 @@ dependencies = [
 [[package]]
 name = "shp-tx-implicits-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14261,7 +14261,7 @@ dependencies = [
 [[package]]
 name = "shp-types"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.6#a923d5cad81582f2c384d6fa175d84102ff80694"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.2.8#c7b5a8d53b80f2521eadc7feb5ba6cda1f76f198"
 dependencies = [
  "sp-core",
  "sp-runtime",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -266,42 +266,42 @@ fc-storage = { git = "https://github.com/polkadot-evm/frontier", branch = "stabl
 
 # StorageHub
 ## Runtime
-pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
+pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
 ## Client
-shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
-shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
+shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
+shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
 ## Precompiles
-pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.6", default-features = false }
+pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.2.8", default-features = false }
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of


### PR DESCRIPTION
Upgrade to StorageHub release version v0.2.8. This is just a patch release with some non-breaking bug fixes and improvements to logs.