### PR TITLE
feat: :loud_sound: Add CPUs log at startup

### DIFF
--- a/operator/node/src/command.rs
+++ b/operator/node/src/command.rs
@@ -388,6 +388,13 @@ pub fn run() -> sc_cli::Result<()> {
                 ));
             };
 
+            if let Some(logical_cpus) = std::thread::available_parallelism().map(|n| n.get()).ok() {
+                log::info!(
+                    "💻 DataHaven node starting with {} logical CPU(s) visible to the process",
+                    logical_cpus
+                );
+            }
+
             runner.run_node_until_exit(|config| async move {
                 let sealing_mode = match (cli.sealing, config.chain_spec.chain_type()) {
                     (Some(mode), ChainType::Development) => Some(mode),

--- a/operator/node/src/rpc.rs
+++ b/operator/node/src/rpc.rs
@@ -202,7 +202,7 @@ where
 
     let signers = Vec::new();
     let pending_consensus_data_provider: Option<
-        Box<(dyn fc_rpc::pending::ConsensusDataProvider<_>)>,
+        Box<dyn fc_rpc::pending::ConsensusDataProvider<_>>,
     > = Some(BabeConsensusDataProvider::new().into());
 
     let pending_create_inherent_data_providers = move |_, _| async move {


### PR DESCRIPTION
Adds a log at the startup of the node to show the number of logical CPUs available to use for parallelism.