### PR TITLE
revert: ♻  Revert Rust toolchain to 1.88.0 (revert PR #362)

### DIFF
--- a/.github/workflows/task-check-licenses.yml
+++ b/.github/workflows/task-check-licenses.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.90.0
+          toolchain: 1.88.0
           override: true
       - name: Verify Licenses
         working-directory: operator

--- a/operator/rust-toolchain.toml
+++ b/operator/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.88.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Revert #362, back to Rust toolchain v1.88.0, as the newer version causes an issue in the runtime release publishing flow.