### PR TITLE
fix: 🔧 account for storage reads on withdrawal

### DIFF
--- a/operator/precompiles/erc20-balances/src/lib.rs
+++ b/operator/precompiles/erc20-balances/src/lib.rs
@@ -446,6 +446,9 @@ where
         let account_amount: U256 = {
             let owner: Runtime::AccountId =
                 Runtime::AddressMapping::into_account_id(handle.context().caller);
+            // frame_system::Account:
+            // Blake2128(16) + AccountId(20) + AccountInfo ((4 * 4) + AccountData(16 * 4))
+            handle.record_db_read::<Runtime>(116)?;
             pallet_balances::Pallet::<Runtime, Instance>::usable_balance(&owner).into()
         };
 


### PR DESCRIPTION
## Summary
ERC20 balances precompile `withdraw()` was failing to account for gas costs associated with storage reads. In fact the function was calling `usable_balance` without accounting for `record_db_read`.

## Changes
- Added `116 bytes` of storage read computed like this: `Blake2128(16) + AccountId(20) + AccountInfo ((4 * 4) + AccountData(16 * 4))`, to cover for `usable_balance`, following the same that `balance_of` does.

