### PR TITLE
fix: 🐛 Align ProxyType enum in Proxy precompile with runtime

### DIFF
--- a/operator/precompiles/proxy/Proxy.sol
+++ b/operator/precompiles/proxy/Proxy.sol
@@ -21,8 +21,8 @@ interface Proxy {
         Staking,
         CancelProxy,
         Balances,
-        AuthorMapping,
-        IdentityJudgement
+        IdentityJudgement,
+        SudoOnly
     }
 
     /// @dev Register a proxy account for the sender that is able to make calls on its behalf


### PR DESCRIPTION
## Summary

- Fixed `ProxyType` enum in the Solidity Proxy precompile interface to match the runtime definition
- Removed non-existent `AuthorMapping` variant
- Added missing `SudoOnly` variant

## Problem

The Solidity interface in `Proxy.sol` had incorrect `ProxyType` enum values that didn't match the runtime definition:

| Index | Runtime (Correct) | Solidity (Was) |
|-------|------------------|----------------|
| 0 | Any | Any |
| 1 | NonTransfer | NonTransfer |
| 2 | Governance | Governance |
| 3 | Staking | Staking |
| 4 | CancelProxy | CancelProxy |
| 5 | Balances | Balances |
| 6 | **IdentityJudgement** | **AuthorMapping** ❌ |
| 7 | **SudoOnly** | **IdentityJudgement** ❌ |

This mismatch would cause EVM users calling the Proxy precompile with `IdentityJudgement` (index 7 in Solidity) to actually get `SudoOnly` behavior, and `AuthorMapping` (index 6) would fail to decode entirely since it doesn't exist in the runtime.

## Solution

Updated the Solidity enum to match the runtime:
```solidity
enum ProxyType {
    Any,
    NonTransfer,
    Governance,
    Staking,
    CancelProxy,
    Balances,
    IdentityJudgement,
    SudoOnly
}
```

## ⚠️ Breaking Changes ⚠️

- **`ProxyType.AuthorMapping` removed**: This variant never existed in the runtime and would fail to decode.
- **`ProxyType.IdentityJudgement` index changed**: Moved from index 7 to index 6. Solidity code using `ProxyType.IdentityJudgement` will now work correctly (previously it mapped to `SudoOnly` in the runtime)
- **`ProxyType.SudoOnly` added**: New variant at index 7 for proxies that can only execute Sudo pallet calls

## Test plan

- [x] Proxy precompile tests pass (32/32)
- [x] Mainnet runtime proxy tests pass (22/22)
- [x] Governance proxy tests pass (6/6)
- [x] Verified `InstanceFilter<RuntimeCall>` implementation handles all 8 variants correctly
- [x] Verified `EvmProxyCallFilter` implementation handles all 8 variants correctly