### PR TITLE
build: :arrow_up: Upgrade to SH v0.3.5

### DIFF
--- a/operator/Cargo.lock
+++ b/operator/Cargo.lock
@@ -8618,8 +8618,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bucket-nfts"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8675,8 +8675,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-cr-randomness"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8959,8 +8959,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-file-system"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "fp-account",
  "fp-evm",
@@ -9199,8 +9199,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-file-system"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9226,8 +9226,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-file-system-runtime-api"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9422,8 +9422,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-payment-streams"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9442,8 +9442,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-payment-streams-runtime-api"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9470,8 +9470,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-proofs-dealer"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9492,8 +9492,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-proofs-dealer-runtime-api"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9514,8 +9514,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9655,8 +9655,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-storage-providers"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9677,8 +9677,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-storage-providers-runtime-api"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13840,8 +13840,8 @@ dependencies = [
 
 [[package]]
 name = "shc-actors-derive"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -13853,8 +13853,8 @@ dependencies = [
 
 [[package]]
 name = "shc-actors-framework"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "bincode",
@@ -13872,8 +13872,8 @@ dependencies = [
 
 [[package]]
 name = "shc-blockchain-service"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -13928,8 +13928,8 @@ dependencies = [
 
 [[package]]
 name = "shc-blockchain-service-db"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "chrono",
  "diesel",
@@ -13952,8 +13952,8 @@ dependencies = [
 
 [[package]]
 name = "shc-client"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -14026,8 +14026,8 @@ dependencies = [
 
 [[package]]
 name = "shc-common"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -14090,8 +14090,8 @@ dependencies = [
 
 [[package]]
 name = "shc-file-manager"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "bincode",
  "hash-db",
@@ -14114,8 +14114,8 @@ dependencies = [
 
 [[package]]
 name = "shc-file-transfer-service"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -14143,8 +14143,8 @@ dependencies = [
 
 [[package]]
 name = "shc-fisherman-service"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "async-trait",
  "diesel",
@@ -14174,8 +14174,8 @@ dependencies = [
 
 [[package]]
 name = "shc-forest-manager"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14200,8 +14200,8 @@ dependencies = [
 
 [[package]]
 name = "shc-indexer-db"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -14228,8 +14228,8 @@ dependencies = [
 
 [[package]]
 name = "shc-indexer-service"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "anyhow",
  "array-bytes",
@@ -14279,8 +14279,8 @@ dependencies = [
 
 [[package]]
 name = "shc-rpc"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -14325,8 +14325,8 @@ dependencies = [
 
 [[package]]
 name = "shc-telemetry"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14342,8 +14342,8 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shp-constants"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -14351,8 +14351,8 @@ dependencies = [
 
 [[package]]
 name = "shp-data-price-updater"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14366,8 +14366,8 @@ dependencies = [
 
 [[package]]
 name = "shp-file-key-verifier"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14384,8 +14384,8 @@ dependencies = [
 
 [[package]]
 name = "shp-file-metadata"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "hex",
  "num-bigint",
@@ -14400,8 +14400,8 @@ dependencies = [
 
 [[package]]
 name = "shp-forest-verifier"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14417,16 +14417,16 @@ dependencies = [
 
 [[package]]
 name = "shp-opaque"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "sp-runtime",
 ]
 
 [[package]]
 name = "shp-session-keys"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14440,8 +14440,8 @@ dependencies = [
 
 [[package]]
 name = "shp-traits"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14454,8 +14454,8 @@ dependencies = [
 
 [[package]]
 name = "shp-treasury-funding"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "log",
  "shp-traits",
@@ -14465,8 +14465,8 @@ dependencies = [
 
 [[package]]
 name = "shp-tx-implicits-runtime-api"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14478,8 +14478,8 @@ dependencies = [
 
 [[package]]
 name = "shp-types"
-version = "0.3.3"
-source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.3#57d2a195d58d39e0d6e38a927ec312dd0f640522"
+version = "0.3.5"
+source = "git+https://github.com/Moonsong-Labs/storage-hub.git?tag=v0.3.5#e21f2316c07e9fc43fc67f20373e6c24a8f4d5ae"
 dependencies = [
  "sp-core",
  "sp-runtime",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -265,42 +265,42 @@ fc-storage = { git = "https://github.com/polkadot-evm/frontier", branch = "stabl
 
 # StorageHub
 ## Runtime
-pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
+pallet-bucket-nfts = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-cr-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-file-system-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-payment-streams = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-payment-streams-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-proofs-dealer = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-proofs-dealer-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-randomness = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-storage-providers = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+pallet-storage-providers-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-constants = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-data-price-updater = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-file-key-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-file-metadata = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-forest-verifier = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-traits = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-treasury-funding = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
 ## Client
-shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
-shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
+shc-actors-derive = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-actors-framework = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-blockchain-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-client = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-common = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-file-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-file-transfer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-fisherman-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-forest-manager = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-indexer-db = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-indexer-service = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shc-rpc = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-opaque = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-tx-implicits-runtime-api = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
+shp-types = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
 ## Precompiles
-pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.3", default-features = false }
+pallet-evm-precompile-file-system = { git = "https://github.com/Moonsong-Labs/storage-hub.git", tag = "v0.3.5", default-features = false }
 
 
 # Static linking

--- a/operator/node/src/cli.rs
+++ b/operator/node/src/cli.rs
@@ -24,6 +24,7 @@ use shc_client::builder::{
     BspUploadFileOptions, FishermanOptions, IndexerOptions, MspChargeFeesOptions,
     MspMoveBucketOptions,
 };
+use shc_indexer_db::models::{FileFiltering, FileOrdering};
 use shc_indexer_service::IndexerMode;
 use shc_rpc::RpcConfig;
 use shp_types::StorageDataUnit;
@@ -300,6 +301,15 @@ pub struct ProviderConfigurations {
     #[arg(long, value_name = "COUNT", default_value = "1024")]
     pub internal_buffer_size: Option<u64>,
 
+    /// Maximum number of MSP respond storage requests to batch together (default: 20)
+    #[arg(
+        long,
+        value_name = "COUNT",
+        help_heading = "Blockchain Service Options",
+        default_value = "20"
+    )]
+    pub msp_respond_storage_batch_size: Option<u32>,
+
     // ============== MSP Charge Fees task options ==============
     /// Enable and configure MSP Charge Fees task.
     #[arg(long)]
@@ -382,6 +392,15 @@ pub struct ProviderConfigurations {
         ])
     )]
     pub bsp_upload_file_max_tip: Option<u128>,
+
+    /// Maximum number of BSP confirm storing requests to batch together (default: 20)
+    #[arg(
+        long,
+        value_name = "COUNT",
+        help_heading = "Blockchain Service Options",
+        default_value = "20"
+    )]
+    pub bsp_confirm_file_batch_size: Option<u32>,
 
     // ============== BSP Move Bucket task options ==============
     /// Enable and configure BSP Move Bucket task.
@@ -593,6 +612,16 @@ impl ProviderConfigurations {
             bs_changed = true;
         }
 
+        if let Some(bsp_confirm_file_batch_size) = self.bsp_confirm_file_batch_size {
+            bs_options.bsp_confirm_file_batch_size = Some(bsp_confirm_file_batch_size);
+            bs_changed = true;
+        }
+
+        if let Some(msp_respond_storage_batch_size) = self.msp_respond_storage_batch_size {
+            bs_options.msp_respond_storage_batch_size = Some(msp_respond_storage_batch_size);
+            bs_changed = true;
+        }
+
         // Set MSP distribution flag if provided on CLI and role is MSP
         if self.msp_distribute_files && provider_type == ProviderType::Msp {
             bs_options.enable_msp_distribute_files = Some(true);
@@ -674,6 +703,26 @@ impl IndexerConfigurations {
     }
 }
 
+/// Filtering strategy for fisherman pending deletion queries.
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum FishermanFiltering {
+    /// No filtering - process all pending deletions (default).
+    #[default]
+    None,
+    /// TTL-based filtering - skip deletions pending longer than threshold.
+    Ttl,
+}
+
+/// Ordering strategy for fisherman pending deletion queries.
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum FishermanOrdering {
+    /// Chronological ordering - process oldest deletions first (FIFO, default).
+    #[default]
+    Chronological,
+    /// Randomized ordering - shuffle processing order.
+    Randomized,
+}
+
 #[derive(Debug, Parser, Clone)]
 pub struct FishermanConfigurations {
     /// Enable the fisherman service.
@@ -698,11 +747,55 @@ pub struct FishermanConfigurations {
     /// Maximum number of files to process per batch deletion cycle.
     #[arg(long, default_value = "1000", value_parser = clap::value_parser!(u64).range(1..))]
     pub fisherman_batch_deletion_limit: u64,
+
+    /// Filtering strategy for pending deletions.
+    #[arg(
+        long,
+        value_enum,
+        default_value = "none",
+        help_heading = "Fisherman Strategy Options"
+    )]
+    pub fisherman_filtering: FishermanFiltering,
+
+    /// Ordering strategy for pending deletions.
+    #[arg(
+        long,
+        value_enum,
+        default_value = "chronological",
+        help_heading = "Fisherman Strategy Options"
+    )]
+    pub fisherman_ordering: FishermanOrdering,
+
+    /// TTL threshold in seconds for pending deletions.
+    /// Files that have been pending deletion for longer than this threshold are skipped.
+    /// Required when --fisherman-filtering=ttl.
+    #[arg(
+        long,
+        value_parser = clap::value_parser!(u64).range(1..),
+        required_if_eq("fisherman_filtering", "ttl"),
+        help_heading = "Fisherman Strategy Options"
+    )]
+    pub fisherman_ttl_threshold_seconds: Option<u64>,
 }
 
 impl FishermanConfigurations {
     pub fn fisherman_options(&self) -> Option<FishermanOptions> {
         if self.fisherman {
+            // Convert CLI enums to indexer-db enums
+            let filtering = match self.fisherman_filtering {
+                FishermanFiltering::None => FileFiltering::None,
+                FishermanFiltering::Ttl => FileFiltering::Ttl {
+                    threshold_seconds: self
+                        .fisherman_ttl_threshold_seconds
+                        .expect("Required when filtering=ttl"),
+                },
+            };
+
+            let ordering = match self.fisherman_ordering {
+                FishermanOrdering::Chronological => FileOrdering::Chronological,
+                FishermanOrdering::Randomized => FileOrdering::Randomized,
+            };
+
             Some(FishermanOptions {
                 database_url: self
                     .fisherman_database_url
@@ -711,6 +804,8 @@ impl FishermanConfigurations {
                 batch_interval_seconds: self.fisherman_batch_interval_seconds,
                 batch_deletion_limit: self.fisherman_batch_deletion_limit,
                 maintenance_mode: false, // Skipping maintenance mode for now
+                filtering,
+                ordering,
             })
         } else {
             None


### PR DESCRIPTION
Upgrades StorageHub dependencies from v0.3.3 to v0.3.5. This requires a client upgrade.

## ⚠️ Breaking Changes ⚠️
  
  Fisherman CLI options have been added to support specifying filtering and ordering strategies for pending file deletions with reasonable defaults:
  
  - `--fisherman-filtering`: The filtering strategy [**`none` (default)**, `ttl`]
  - `--fisherman-ordering`: The ordering strategy [**`chronological` (default)**, `randomized`]
  - `--fisherman-ttl-threshold-seconds`: TTL for a file to be ignored for deletion in seconds
  
  MSP and BSP CLI options have been added to support specifying a specific batch response and confirm size for MSP and BSP nodes with reasonable defaults.
  
  - `--bsp-confirm-file-batch-size`: How many storage requests to respond to (confirming) in a single extrinsic call **(default: 20)**
  - `--msp-respond-storage-batch-size`: How many storage requests to respond to (accepting or rejecting) in a single extrinsic call **(default: 20)**

  