### PR TITLE
ci: migrate from self-hosted to standard GitHub runners

### DIFF
--- a/.github/workflows/actions/setup-env/action.yml
+++ b/.github/workflows/actions/setup-env/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "cache"
   
   install-deps:
-    description: "Whether to install system dependencies. Set to false for self-hosted runners with pre-installed deps"
+    description: "Whether to install system dependencies via apt. Set to false to install dependencies locally without sudo."
     required: false
     default: "true"
 
@@ -128,9 +128,9 @@ runs:
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y libpq-dev libclang-dev
     
-    # Auto-install missing dependencies when install-deps is false (for self-hosted runners)
+    # Auto-install missing dependencies locally when install-deps is false (no sudo required)
     # Note: PATH and env vars are already set up in "Setup paths for cached tools" step
-    - name: Setup system dependencies (self-hosted)
+    - name: Setup system dependencies (local install)
       if: inputs.install-deps == 'false'
       shell: bash
       run: |
@@ -226,8 +226,8 @@ runs:
       with:
         repo-token: ${{ github.token }}
     
-    # Auto-install protoc when install-deps is false (for self-hosted runners)
-    - name: Setup Protoc (self-hosted)
+    # Auto-install protoc locally when install-deps is false (no sudo required)
+    - name: Setup Protoc (local install)
       if: inputs.install-deps == 'false'
       shell: bash
       run: |

--- a/.github/workflows/task-build-operator.yml
+++ b/.github/workflows/task-build-operator.yml
@@ -20,8 +20,7 @@ jobs:
     outputs:
       binary-hash: ${{ steps.hash-binary.outputs.datahaven-node-hash }}
     name: Build operator binary
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
@@ -42,7 +41,6 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: BUILD-RELEASE
-          install-deps: false
 
       - name: Set build flags
         run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV

--- a/.github/workflows/task-build-static-operator.yaml
+++ b/.github/workflows/task-build-static-operator.yaml
@@ -10,8 +10,7 @@ on:
 jobs:
   build-node:
     name: Build operator binary
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
@@ -29,8 +28,6 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: BUILD-RELEASE
-          install-deps: false
-          skip-libpq: true
 
       - name: Set build flags
         run: echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV

--- a/.github/workflows/task-e2e.yml
+++ b/.github/workflows/task-e2e.yml
@@ -34,7 +34,7 @@ permissions:
 env:
   FOUNDRY_PROFILE: ci
   LOG_LEVEL: debug
-  DOCKER_HOST: unix:///run/user/1020/podman/podman.sock
+  # DOCKER_HOST: unix:///run/user/1020/podman/podman.sock  # was: self-hosted podman socket
   KURTOSIS_CORE_IMAGE: docker.io/kurtosistech/core
   KURTOSIS_ENGINE_IMAGE: docker.io/kurtosistech/engine
   KURTOSIS_VERSION: 1.15.2
@@ -42,8 +42,9 @@ env:
 
 jobs:
   kurtosis:
-    runs-on:
-      group: DH-Testing
+    runs-on: ubuntu-latest
+    # was: runs-on:
+    #        group: DH-Testing
     name: E2E Tests with Kurtosis Ethereum Network
     defaults:
       run:
@@ -91,27 +92,26 @@ jobs:
           fi
           kurtosis analytics disable
           kurtosis version
-      - name: Configure Kurtosis cluster = podman
+      # was: podman cluster config for self-hosted runner
+      # - name: Configure Kurtosis cluster = podman
+      #   run: |
+      #     CFG_PATH="$(kurtosis config path)"
+      #     mkdir -p "$(dirname "$CFG_PATH")"
+      #     cat > "$CFG_PATH" <<'YML'
+      #     config-version: 6
+      #     should-send-metrics: true
+      #     kurtosis-clusters:
+      #       docker:
+      #         type: "docker"
+      #       podman:
+      #         type: "podman"
+      #     YML
+      #     kurtosis cluster set podman
+      #     kurtosis cluster get
+      - name: Start Kurtosis engine
         run: |
-          # Get the config path from Kurtosis itself (portable)
-          CFG_PATH="$(kurtosis config path)"
-          mkdir -p "$(dirname "$CFG_PATH")"
-          # Create/update config with a podman cluster entry
-          cat > "$CFG_PATH" <<'YML'
-          config-version: 6
-          should-send-metrics: true
-          kurtosis-clusters:
-            docker:
-              type: "docker"
-            podman:
-              type: "podman"
-          YML
-          kurtosis cluster set podman
-          kurtosis cluster get
-      - name: Start Kurtosis engine with Podman
-        run: |
-          kurtosis engine stop
-          kurtosis clean
+          kurtosis engine stop || true
+          kurtosis clean || true
           kurtosis engine start
           kurtosis engine status
       - uses: actions/cache@v4
@@ -154,4 +154,5 @@ jobs:
 
       - name: Delete volumes not used
         if: always()
-        run: podman system prune --volumes -f
+        run: docker system prune --volumes -f
+        # was: podman system prune --volumes -f

--- a/.github/workflows/task-publish-binary.yml
+++ b/.github/workflows/task-publish-binary.yml
@@ -31,8 +31,7 @@ jobs:
           retention-days: 1
 
   build-binary:
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     needs: ["prepare-sources"]
     permissions:
       contents: read

--- a/.github/workflows/task-rust-lint.yml
+++ b/.github/workflows/task-rust-lint.yml
@@ -27,8 +27,7 @@ env:
 jobs:
   cargo-fmt:
     name: "Check format with rustfmt"
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIR }}
@@ -38,15 +37,13 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: FMT
-          install-deps: false  # Self-hosted runners have deps pre-installed
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
   check-rust-lint:
     name: "Check lint with clippy"
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIR }}
@@ -56,7 +53,6 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: LINT
-          install-deps: false  # Self-hosted runners have deps pre-installed
 
       - name: Set build flags
         run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
@@ -66,8 +62,7 @@ jobs:
 
   check-cargo-sort:
     name: "Check Cargo sort"
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/task-rust-tests.yml
+++ b/.github/workflows/task-rust-tests.yml
@@ -13,8 +13,7 @@ permissions:
 jobs:
   rust-tests:
     name: Run Operator Rust tests
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
@@ -32,7 +31,6 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: "TEST"
-          install-deps: false
 
       - name: Set build flags
         run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV

--- a/.github/workflows/task-warm-sccache.yml
+++ b/.github/workflows/task-warm-sccache.yml
@@ -15,8 +15,7 @@ permissions:
 jobs:
   warm-cache:
     name: Warm sccache cache
-    runs-on:
-      group: DH-runners
+    runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
@@ -34,7 +33,6 @@ jobs:
       - uses: ./.github/workflows/actions/setup-env
         with:
           cache-key: WARM
-          install-deps: false
 
       - name: Set build flags
         run: echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Self-hosted `DH-runners` have been decommissioned — all Rust build, test, and lint workflows now use `ubuntu-latest`
- Removed `install-deps: false` overrides so workflows use the default apt-based dependency installation path
- Updated `setup-env` action descriptions to remove self-hosted runner references

### Workflows updated
- `task-build-operator.yml`
- `task-build-static-operator.yaml`
- `task-publish-binary.yml`
- `task-rust-lint.yml` (3 jobs)
- `task-rust-tests.yml`
- `task-warm-sccache.yml`
- `task-e2e.yml`

## Test plan
- [x] Verify all Rust CI jobs pass on `ubuntu-latest` (build, lint, test, warm-cache)
- [x] Confirm sccache and dependency installation work correctly on standard runners
- [x] Ensure E2E workflow runs with Docker (instead of Podman) on standard runners